### PR TITLE
Update README for Engineering Lead position

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,47 +1,36 @@
-## Hi Guys 🖖🏽
-My name is Marlon, if you prefer you can call me Marliton, I was born on planet Earth (Bogotá DC, Colombia 🇨🇴).
+# Marlon Barreto
+**Engineering Lead** | Bogotá, Colombia 🇨🇴
 
-- 🔭 I’m currently working as Sr Software Engineer.
-- 🤗 I’m currently learning to program and trying to be 1% better every day.
-- 🎧 I like rock, jazz, blues and maybe some Dua Lipa. 🎶
+*Building high-scale distributed systems and empowering engineering teams to deliver exceptional products*
 
-### 🌐 Socials
+## About
+- **Engineering Lead** with 7+ years developing backend systems and leading cross-functional teams
+- Specialized in **distributed architectures**, microservices, and cloud-native applications at scale
+- Leading teams of 8+ engineers across multiple time zones and product verticals
+- Passionate about **system design**, performance optimization, and engineering culture
+- Mentoring engineers in career growth and technical excellence
+
+## Core Technologies
+
+**Backend & Systems**: Go • Python • Java  
+**Cloud & Infrastructure**: AWS • Kubernetes • Docker • Terraform  
+**Data**: PostgreSQL • Redis • Message Queues  
+**Observability**: DataDog • Prometheus • Distributed Tracing
+
+## What I Focus On
+- 🏗️ **System Architecture** - Designing resilient, scalable distributed systems
+- 👥 **Team Leadership** - Building and mentoring high-performing engineering teams  
+- 🚀 **Technical Strategy** - Driving architecture decisions and technology adoption
+- 📈 **Performance Engineering** - Optimizing systems for scale and reliability
+
+## Currently Exploring
+Integrating AI/ML capabilities into distributed payment processing systems
+
+### Connect
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-%230077B5.svg?logo=linkedin&logoColor=white)](https://www.linkedin.com/in/marlon-andres-bt/)
 
-# 💻 Tech Stack
-![Go](https://img.shields.io/badge/go-%2300ADD8.svg?style=for-the-badge&logo=go&logoColor=white)
-![C](https://img.shields.io/badge/c-%2300599C.svg?style=for-the-badge&logo=c&logoColor=white)
-![C++](https://img.shields.io/badge/c++-%2300599C.svg?style=for-the-badge&logo=c%2B%2B&logoColor=white)
-![Python](https://img.shields.io/badge/python-3670A0?style=for-the-badge&logo=python&logoColor=ffdd54)
-![Kotlin](https://img.shields.io/badge/kotlin-%237e08d4.svg?style=for-the-badge&logo=kotlin&logoColor=white)
-![Java](https://img.shields.io/badge/java-%23ED8B00.svg?style=for-the-badge&logo=java&logoColor=white)
-![Spring](https://img.shields.io/badge/spring-%236DB33F.svg?style=for-the-badge&logo=spring&logoColor=white)
-![Gradle](https://img.shields.io/badge/Gradle-02303A.svg?style=for-the-badge&logo=Gradle&logoColor=white)
-![MySQL](https://img.shields.io/badge/mysql-%2300f.svg?style=for-the-badge&logo=mysql&logoColor=white)
-![PostgreSQL](https://img.shields.io/badge/postgresql-%23397098.svg?style=for-the-badge&logo=postgresql&logoColor=white)
-![Postman](https://img.shields.io/badge/Postman-FF6C37?style=for-the-badge&logo=postman&logoColor=white)
-![Swagger](https://img.shields.io/badge/-Swagger-%23Clojure?style=for-the-badge&logo=swagger&logoColor=white)
-![JavaScript](https://img.shields.io/badge/javascript-%23323330.svg?style=for-the-badge&logo=javascript&logoColor=%23F7DF1E)
-![TypeScript](https://img.shields.io/badge/typescript-%23007ACC.svg?style=for-the-badge&logo=typescript&logoColor=white)
-![Express.js](https://img.shields.io/badge/express.js-%23404d59.svg?style=for-the-badge&logo=express&logoColor=%2361DAFB)
-![NodeJS](https://img.shields.io/badge/node.js-6DA55F?style=for-the-badge&logo=node.js&logoColor=white)
-![HTML5](https://img.shields.io/badge/html5-%23E34F26.svg?style=for-the-badge&logo=html5&logoColor=white)
-![React](https://img.shields.io/badge/react-%2320232a.svg?style=for-the-badge&logo=react&logoColor=%2361DAFB)
-![Markdown](https://img.shields.io/badge/markdown-%23000000.svg?style=for-the-badge&logo=markdown&logoColor=white)
-![Datadog](https://img.shields.io/badge/datadog-%23632CA6.svg?style=for-the-badge&logo=datadog&logoColor=white)
-![Firebase](https://img.shields.io/badge/firebase-%23039BE5.svg?style=for-the-badge&logo=firebase)
-![AWS](https://img.shields.io/badge/aws-%23ED8B00.svg?style=for-the-badge&logo=amazonwebservices&logoColor=white)
-![Confluence](https://img.shields.io/badge/confluence-%23172BF4.svg?style=for-the-badge&logo=confluence&logoColor=white)
-![Jira](https://img.shields.io/badge/jira-%230A0FFF.svg?style=for-the-badge&logo=jira&logoColor=white)
-![ClickUp](https://img.shields.io/badge/ClickUp-%23ff0077.svg?style=for-the-badge&logo=clickup&logoColor=white)
+## GitHub Stats
 
-## 📈 Github Stats
+[![GitHub Stats](https://github-readme-stats.vercel.app/api?username=marlonbarreto-git&show_icons=true&theme=monokai&hide_border=true&border_radius=10&count_private=true)](https://github.com/marlonbarreto-git)
 
-[![Marliton's GitHub Stats](https://github-readme-stats.vercel.app/api?username=marlonbarreto-git&count_private=true&show_icons=true&theme=monokai&hide_border=true&border_radius=10)](https://github.com/marlonbarreto-git)
-
-[![GitHub Streak](https://streak-stats.demolab.com?user=marlonbarreto-git&theme=monokai&hide_border=true&border_radius=10)](https://github.com/marlonbarreto-git)
-
-[![Marliton's GitHub Stats](https://github-readme-stats.vercel.app/api/top-langs/?username=marlonbarreto-git&layout=compact&count_private=true&theme=monokai&hide_border=true&border_radius=10)](https://github.com/marlonbarreto-git)
-
-## 🏆 GitHub Trophies
-[![Marliton's Github Trophies](https://github-profile-trophy.vercel.app/?username=marlonbarreto-git&theme=monokai&no-frame=false&no-bg=false&margin-w=4)](https://github.com/marlonbarreto-git)
+[![Most Used Languages](https://github-readme-stats.vercel.app/api/top-langs/?username=marlonbarreto-git&layout=compact&count_private=true&theme=monokai&hide_border=true&border_radius=10)](https://github.com/marlonbarreto-git)


### PR DESCRIPTION
## Summary
- Transformed README from Senior Engineer to Engineering Lead profile
- Removed excessive technology badges for cleaner, more professional appearance  
- Added focus on leadership, team development, and architectural expertise
- Simplified GitHub stats section while maintaining relevant information

## Changes
- Professional header with Engineering Lead title
- Leadership-focused about section highlighting distributed systems and team leadership
- Removed 20+ technology badges that cluttered the profile
- Kept only essential GitHub language statistics
- More executive tone appropriate for leadership position